### PR TITLE
Convert test pool to be class based instead of method based

### DIFF
--- a/build-scripts/gradle-mvn-push.gradle
+++ b/build-scripts/gradle-mvn-push.gradle
@@ -26,47 +26,7 @@ def getRepositoryPassword() {
 uploadArchives {
     repositories {
         mavenDeployer {
-            beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
-
-            pom.groupId = GROUP
-            pom.artifactId = POM_ARTIFACT_ID
-            pom.version = VERSION_NAME
-
-            repository(url: getReleaseRepositoryUrl()) {
-                authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
-            }
-
-            snapshotRepository(url: getSnapshotRepositoryUrl()) {
-                authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
-            }
-
-            pom.project {
-                name POM_NAME
-                packaging POM_PACKAGING
-                description POM_DESCRIPTION
-                url POM_URL
-
-                scm {
-                    url POM_SCM_URL
-                    connection POM_SCM_CONNECTION
-                    developerConnection POM_SCM_DEV_CONNECTION
-                }
-
-                licenses {
-                    license {
-                        name POM_LICENCE_NAME
-                        url POM_LICENCE_URL
-                        distribution POM_LICENCE_DIST
-                    }
-                }
-
-                developers {
-                    developer {
-                        id POM_DEVELOPER_ID
-                        name POM_DEVELOPER_NAME
-                    }
-                }
-            }
+            repository(url: String.format("file:%s/.m2/repository", System.getProperty("user.home")))
         }
     }
 }

--- a/build-scripts/gradle-mvn-push.gradle
+++ b/build-scripts/gradle-mvn-push.gradle
@@ -23,6 +23,9 @@ def getRepositoryPassword() {
     return hasProperty('NEXUS_PASSWORD') ? NEXUS_PASSWORD : ""
 }
 
+task assembleRelease(dependsOn: 'assemble') << {
+}
+
 uploadArchives {
     repositories {
         mavenDeployer {

--- a/chimprunner/src/main/java/com/shazam/chimprunner/LoggingPerformanceTestListener.java
+++ b/chimprunner/src/main/java/com/shazam/chimprunner/LoggingPerformanceTestListener.java
@@ -39,7 +39,7 @@ class LoggingPerformanceTestListener extends NoOpPerformanceTestListener {
         timings = new ArrayList<>();
         iteration = 0;
         iterationStartTime = 0;
-        logger.info("Starting test {} {}", testCaseEvent.getTestClass(), testCaseEvent.getTestMethod());
+        logger.info("Starting test {} {}", testCaseEvent.getTestClass(), testCaseEvent.getTestMethods());
     }
 
     @Override

--- a/chimprunner/src/main/java/com/shazam/chimprunner/PerformanceTestRunner.java
+++ b/chimprunner/src/main/java/com/shazam/chimprunner/PerformanceTestRunner.java
@@ -55,8 +55,7 @@ public class PerformanceTestRunner {
         RemoteAndroidTestRunner androidTestRunner = new RemoteAndroidTestRunner(instrumentationPackage, testRunner,
                 device.getDeviceInterface());
         String testClassName = testCaseEvent.getTestClass();
-        String testMethodName = testCaseEvent.getTestMethod();
-        androidTestRunner.setMethodName(testClassName, testMethodName);
+        androidTestRunner.setClassName(testClassName);
         androidTestRunner.setMaxtimeToOutputResponse(Defaults.ADB_MAX_TIME_TO_OUTPUT_RESPONSE);
         try {
             PerformanceTestListener performanceTestListener = new LoggingPerformanceTestListener(testCaseEvent, results);
@@ -75,7 +74,7 @@ public class PerformanceTestRunner {
         } catch (ShellCommandUnresponsiveException | TimeoutException e) {
             logger.warn("Test: " + testClassName + " got stuck. You can increase the timeout in settings if it's too strict");
         } catch (AdbCommandRejectedException | IOException e) {
-            throw new RuntimeException(format("Error while running test %s %s", testClassName, testMethodName), e);
+            throw new RuntimeException(format("Error while running test %s", testClassName), e);
         }
     }
 

--- a/chimprunner/src/main/java/com/shazam/chimprunner/ResultsStorage.java
+++ b/chimprunner/src/main/java/com/shazam/chimprunner/ResultsStorage.java
@@ -50,7 +50,7 @@ public class ResultsStorage {
 
         for (Map.Entry<TestCaseEvent, Double> entry : results.entrySet()) {
             TestCaseEvent key = entry.getKey();
-            keys[i] = key.getTestClass() + "_" + key.getTestMethod();
+            keys[i] = key.getTestClass() + "_" + key.getTestMethods();
             values[i] = String.valueOf(entry.getValue());
             i++;
         }

--- a/fork-common/src/main/java/com/shazam/fork/model/TestCaseEvent.java
+++ b/fork-common/src/main/java/com/shazam/fork/model/TestCaseEvent.java
@@ -1,48 +1,52 @@
 package com.shazam.fork.model;
 
-import com.android.ddmlib.testrunner.TestIdentifier;
 import com.google.common.base.Objects;
 
-import javax.annotation.Nonnull;
+import java.util.List;
 
 import static org.apache.commons.lang3.builder.ToStringBuilder.reflectionToString;
 import static org.apache.commons.lang3.builder.ToStringStyle.SIMPLE_STYLE;
 
 public class TestCaseEvent {
 
-    private final String testMethod;
+    private final List<String> testMethods;
+    private final List<String> ignoredMethods;
     private final String testClass;
-    private final boolean isIgnored;
+    private final boolean isClassIgnored;
 
-    private TestCaseEvent(String testMethod, String testClass, boolean isIgnored) {
-        this.testMethod = testMethod;
+    private TestCaseEvent(String testClass, List<String> testMethods, List<String> ignoredMethods, boolean isClassIgnored) {
+        this.testMethods = testMethods;
         this.testClass = testClass;
-        this.isIgnored = isIgnored;
+        this.ignoredMethods = ignoredMethods;
+        this.isClassIgnored = isClassIgnored;
     }
 
-    public static TestCaseEvent newTestCase(String testMethod, String testClass, boolean isIgnored) {
-        return new TestCaseEvent(testMethod, testClass, isIgnored);
+    public static TestCaseEvent newTestCase(String testClass,
+                                            boolean isClassIgnored,
+                                            List<String> testMethods,
+                                            List<String> ignoredMethods) {
+        return new TestCaseEvent(testClass, testMethods, ignoredMethods, isClassIgnored);
     }
 
-    public static TestCaseEvent newTestCase(@Nonnull TestIdentifier testIdentifier, boolean isIgnored) {
-        return new TestCaseEvent(testIdentifier.getTestName(), testIdentifier.getClassName(), isIgnored);
-    }
-
-    public String getTestMethod() {
-        return testMethod;
+    public List<String> getTestMethods() {
+        return testMethods;
     }
 
     public String getTestClass() {
         return testClass;
     }
 
-    public boolean isIgnored() {
-        return isIgnored;
+    public List<String> ignoredMethods() {
+        return ignoredMethods;
+    }
+
+    public boolean isClassIgnored() {
+        return isClassIgnored;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(this.testMethod, this.testClass);
+        return Objects.hashCode(this.testMethods, this.testClass, this.ignoredMethods, this.isClassIgnored);
     }
 
     @Override
@@ -54,7 +58,9 @@ public class TestCaseEvent {
             return false;
         }
         final TestCaseEvent other = (TestCaseEvent) obj;
-        return Objects.equal(this.testMethod, other.testMethod)
+        return Objects.equal(this.testMethods, other.testMethods)
+                && Objects.equal(this.isClassIgnored, other.isClassIgnored)
+                && Objects.equal(this.ignoredMethods, other.ignoredMethods)
                 && Objects.equal(this.testClass, other.testClass);
     }
 

--- a/fork-common/src/main/java/com/shazam/fork/summary/Summary.java
+++ b/fork-common/src/main/java/com/shazam/fork/summary/Summary.java
@@ -73,8 +73,8 @@ public class Summary {
             return this;
         }
 
-        public Builder addIgnoredTest(String s) {
-            this.ignoredTests.add(s);
+        public Builder addIgnoredTests(List<String> ignoredTests) {
+            this.ignoredTests.addAll(ignoredTests);
             return this;
         }
 

--- a/fork-runner/src/main/java/com/shazam/fork/model/PoolTestCaseAccumulator.java
+++ b/fork-runner/src/main/java/com/shazam/fork/model/PoolTestCaseAccumulator.java
@@ -1,9 +1,11 @@
 package com.shazam.fork.model;
 
+import com.android.ddmlib.testrunner.TestIdentifier;
+
 public interface PoolTestCaseAccumulator {
-    void record(Pool pool, TestCaseEvent testCaseEvent);
+    void record(Pool pool, TestIdentifier testIdentifier);
 
-    int getCount(Pool pool, TestCaseEvent testCaseEvent);
+    int getCount(Pool pool, TestIdentifier testIdentifier);
 
-    int getCount(TestCaseEvent testCaseEvent);
+    int getCount(TestIdentifier testIdentifier);
 }

--- a/fork-runner/src/main/java/com/shazam/fork/model/TestCaseEventCounter.java
+++ b/fork-runner/src/main/java/com/shazam/fork/model/TestCaseEventCounter.java
@@ -1,5 +1,6 @@
 package com.shazam.fork.model;
 
+import com.android.ddmlib.testrunner.TestIdentifier;
 import com.google.common.base.Objects;
 
 import java.util.concurrent.atomic.AtomicInteger;
@@ -8,11 +9,11 @@ public class TestCaseEventCounter {
 
     public static final TestCaseEventCounter EMPTY = new TestCaseEventCounter(null, 0);
 
-    private TestCaseEvent testCaseEvent;
+    private TestIdentifier testIdentifier;
     private AtomicInteger count;
 
-    public TestCaseEventCounter(TestCaseEvent testCaseEvent, int initialCount) {
-        this.testCaseEvent = testCaseEvent;
+    public TestCaseEventCounter(TestIdentifier testIdentifier, int initialCount) {
+        this.testIdentifier = testIdentifier;
         this.count = new AtomicInteger(initialCount);
     }
 
@@ -20,8 +21,8 @@ public class TestCaseEventCounter {
         return count.incrementAndGet();
     }
 
-    public TestCaseEvent getTestCaseEvent() {
-        return testCaseEvent;
+    public TestIdentifier getTestIdentifier() {
+        return testIdentifier;
     }
 
     public int getCount() {
@@ -35,7 +36,7 @@ public class TestCaseEventCounter {
 
     @Override
     public int hashCode() {
-        return testCaseEvent.hashCode();
+        return testIdentifier.hashCode();
     }
 
     @Override
@@ -43,6 +44,6 @@ public class TestCaseEventCounter {
         if (obj == null) return false;
         if (getClass() != obj.getClass()) return false;
         final TestCaseEventCounter other = (TestCaseEventCounter) obj;
-        return Objects.equal(this.testCaseEvent, other.testCaseEvent);
+        return Objects.equal(this.testIdentifier, other.testIdentifier);
     }
 }

--- a/fork-runner/src/main/java/com/shazam/fork/runner/OverallProgressReporter.java
+++ b/fork-runner/src/main/java/com/shazam/fork/runner/OverallProgressReporter.java
@@ -10,6 +10,7 @@
 
 package com.shazam.fork.runner;
 
+import com.android.ddmlib.testrunner.TestIdentifier;
 import com.shazam.fork.model.*;
 
 import org.slf4j.Logger;
@@ -91,7 +92,7 @@ public class OverallProgressReporter implements ProgressReporter {
         return progress / size;
     }
 
-    public boolean requestRetry(Pool pool, TestCaseEvent testCase) {
+    public boolean requestRetry(Pool pool, TestIdentifier testCase) {
         boolean result = retryWatchdog.requestRetry(failedTestCasesAccumulator.getCount(testCase));
         if (result && poolProgressTrackers.containsKey(pool)) {
             poolProgressTrackers.get(pool).trackTestEnqueuedAgain();
@@ -100,12 +101,12 @@ public class OverallProgressReporter implements ProgressReporter {
     }
 
     @Override
-    public void recordFailedTestCase(Pool pool, TestCaseEvent testCase) {
+    public void recordFailedTestCase(Pool pool, TestIdentifier testCase) {
         failedTestCasesAccumulator.record(pool, testCase);
     }
 
     @Override
-    public int getTestFailuresCount(Pool pool, TestCaseEvent testCase) {
+    public int getTestFailuresCount(Pool pool, TestIdentifier testCase) {
         return failedTestCasesAccumulator.getCount(pool, testCase);
     }
 

--- a/fork-runner/src/main/java/com/shazam/fork/runner/PoolTestRunnerFactory.java
+++ b/fork-runner/src/main/java/com/shazam/fork/runner/PoolTestRunnerFactory.java
@@ -14,6 +14,7 @@ import com.shazam.fork.model.Pool;
 import com.shazam.fork.model.TestCaseEvent;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.concurrent.CountDownLatch;
 
@@ -29,7 +30,11 @@ public class PoolTestRunnerFactory {
                                          CountDownLatch poolCountDownLatch,
                                          ProgressReporter progressReporter) {
 
-        int totalTests = testCases.size();
+        int totalTests = (int) testCases.stream()
+                                   .map(TestCaseEvent::getTestMethods)
+                                   .flatMap(Collection::stream)
+                                   .count();
+
         progressReporter.addPoolProgress(pool, new PoolProgressTrackerImpl(totalTests));
 
         return new PoolTestRunner(

--- a/fork-runner/src/main/java/com/shazam/fork/runner/ProgressReporter.java
+++ b/fork-runner/src/main/java/com/shazam/fork/runner/ProgressReporter.java
@@ -10,6 +10,7 @@
 
 package com.shazam.fork.runner;
 
+import com.android.ddmlib.testrunner.TestIdentifier;
 import com.shazam.fork.model.Pool;
 import com.shazam.fork.model.TestCaseEvent;
 
@@ -34,9 +35,9 @@ public interface ProgressReporter {
 
     float getProgress();
 
-    boolean requestRetry(Pool pool, TestCaseEvent testCaseEvent);
+    boolean requestRetry(Pool pool, TestIdentifier testCaseEvent);
 
-    void recordFailedTestCase(Pool pool, TestCaseEvent testCase);
+    void recordFailedTestCase(Pool pool, TestIdentifier testCase);
 
-    int getTestFailuresCount(Pool pool, TestCaseEvent testCase);
+    int getTestFailuresCount(Pool pool, TestIdentifier testCase);
 }

--- a/fork-runner/src/main/java/com/shazam/fork/runner/TestRun.java
+++ b/fork-runner/src/main/java/com/shazam/fork/runner/TestRun.java
@@ -44,13 +44,12 @@ class TestRun {
 
 		TestCaseEvent test = testRunParameters.getTest();
 		String testClassName = test.getTestClass();
-		String testMethodName = test.getTestMethod();
 		IRemoteAndroidTestRunner.TestSize testSize = testRunParameters.getTestSize();
 		if (testSize != null) {
 			runner.setTestSize(testSize);
 		}
 		runner.setRunName(poolName);
-		runner.setMethodName(testClassName, testMethodName);
+		runner.setClassName(testClassName);
 		runner.setMaxtimeToOutputResponse(testRunParameters.getTestOutputTimeout());
 
         if (testRunParameters.isCoverageEnabled()) {
@@ -63,7 +62,7 @@ class TestRun {
 		} catch (ShellCommandUnresponsiveException | TimeoutException e) {
 			logger.warn("Test: " + testClassName + " got stuck. You can increase the timeout in settings if it's too strict");
 		} catch (AdbCommandRejectedException | IOException e) {
-			throw new RuntimeException(format("Error while running test %s %s", test.getTestClass(), test.getTestMethod()), e);
+			throw new RuntimeException(format("Error while running test %s", test.getTestClass()), e);
 		}
 	}
 }

--- a/fork-runner/src/main/java/com/shazam/fork/runner/listeners/CoverageListener.java
+++ b/fork-runner/src/main/java/com/shazam/fork/runner/listeners/CoverageListener.java
@@ -21,6 +21,7 @@ public class CoverageListener implements ITestRunListener {
     private final Pool pool;
     private final Logger logger = LoggerFactory.getLogger(CoverageListener.class);
     private final TestCaseEvent testCase;
+    private TestIdentifier currentTest;
 
     public CoverageListener(Device device, FileManager fileManager, Pool pool, TestCaseEvent testCase) {
         this.device = device;
@@ -35,6 +36,7 @@ public class CoverageListener implements ITestRunListener {
 
     @Override
     public void testStarted(TestIdentifier test) {
+        currentTest = test;
     }
 
     @Override
@@ -64,7 +66,7 @@ public class CoverageListener implements ITestRunListener {
     @Override
     public void testRunEnded(long elapsedTime, Map<String, String> runMetrics) {
         final String remoteFile = RemoteFileManager.getCoverageFileName(testCase.getTestClass());
-        final File file = fileManager.createFile(COVERAGE, pool, device, testCase);
+        final File file = fileManager.createFile(COVERAGE, pool, device, currentTest);
         try {
             device.getDeviceInterface().pullFile(remoteFile, file.getAbsolutePath());
         } catch (Exception e) {

--- a/fork-runner/src/main/java/com/shazam/fork/runner/listeners/ForkXmlTestRunListener.java
+++ b/fork-runner/src/main/java/com/shazam/fork/runner/listeners/ForkXmlTestRunListener.java
@@ -53,7 +53,7 @@ public class ForkXmlTestRunListener extends XmlTestRunListener {
 
     @Override
     protected File getResultFile(File reportDir) {
-        return fileManager.createFile(FileType.TEST, pool, device, testCase);
+        return fileManager.createFile(FileType.TEST, pool, device, test);
     }
 
     @Override
@@ -67,7 +67,7 @@ public class ForkXmlTestRunListener extends XmlTestRunListener {
         ImmutableMap.Builder<String, String> mapBuilder = ImmutableMap.<String, String>builder()
                 .putAll(super.getPropertiesAttributes());
         if (test != null) {
-            int testFailuresCount = progressReporter.getTestFailuresCount(pool, newTestCase(test, false));
+            int testFailuresCount = progressReporter.getTestFailuresCount(pool, test);
             if (testFailuresCount > 0) {
                 mapBuilder
                         .put(SUMMARY_KEY_TOTAL_FAILURE_COUNT, Integer.toString(testFailuresCount))

--- a/fork-runner/src/main/java/com/shazam/fork/runner/listeners/RetryListener.java
+++ b/fork-runner/src/main/java/com/shazam/fork/runner/listeners/RetryListener.java
@@ -66,14 +66,14 @@ public class RetryListener extends NoOpITestRunListener {
     @Override
     public void testFailed(TestIdentifier test, String trace) {
         failedTest = test;
-        progressReporter.recordFailedTestCase(pool, newTestCase(failedTest, false));
+        progressReporter.recordFailedTestCase(pool, test);
     }
 
     @Override
     public void testRunEnded(long elapsedTime, Map<String, String> runMetrics) {
         super.testRunEnded(elapsedTime, runMetrics);
         if (failedTest != null) {
-            if (progressReporter.requestRetry(pool, newTestCase(failedTest, false))) {
+            if (progressReporter.requestRetry(pool, failedTest)) {
                 queueOfTestsInPool.add(currentTestCaseEvent);
                 logger.info("Test " + failedTest.toString() + " enqueued again into pool:" + pool.getName());
                 removeFailureTraceFiles();

--- a/fork-runner/src/main/java/com/shazam/fork/runner/listeners/TestRunListenersFactory.java
+++ b/fork-runner/src/main/java/com/shazam/fork/runner/listeners/TestRunListenersFactory.java
@@ -49,8 +49,7 @@ public class TestRunListenersFactory {
         return asList(
                 new ProgressTestRunListener(pool, progressReporter),
                 getForkXmlTestRunListener(fileManager, configuration.getOutput(), pool, device, testCase, progressReporter),
-                new ConsoleLoggingTestRunListener(configuration.getTestPackage(), device.getSerial(),
-                        device.getModelName(), progressReporter),
+                new ConsoleLoggingTestRunListener(configuration.getTestPackage(), device.getSerial(), device.getModelName(), progressReporter),
                 new LogCatTestRunListener(gson, fileManager, pool, device),
                 new SlowWarningTestRunListener(),
                 getScreenTraceTestRunListener(fileManager, pool, device),

--- a/fork-runner/src/main/java/com/shazam/fork/summary/SummaryCompiler.java
+++ b/fork-runner/src/main/java/com/shazam/fork/summary/SummaryCompiler.java
@@ -23,7 +23,9 @@ import org.simpleframework.xml.core.Persister;
 
 import java.io.File;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.shazam.fork.model.Device.Builder.aDevice;
 import static com.shazam.fork.summary.PoolSummary.Builder.aPoolSummary;
@@ -89,9 +91,11 @@ public class SummaryCompiler {
 
     private void addIgnoredTests(Collection<TestCaseEvent> testCases, Summary.Builder summaryBuilder) {
         for (TestCaseEvent testCase : testCases) {
-            if (testCase.isIgnored()) {
-                summaryBuilder.addIgnoredTest(testCase.getTestClass() + ":" + testCase.getTestMethod());
-            }
+            summaryBuilder.addIgnoredTests(testCase.ignoredMethods()
+                                                   .stream()
+                                                   .map(method -> String.format("%s:%s", testCase.getTestClass(), method))
+                                                   .collect(Collectors.toList()));
+
         }
     }
 

--- a/fork-runner/src/main/java/com/shazam/fork/system/io/FileManager.java
+++ b/fork-runner/src/main/java/com/shazam/fork/system/io/FileManager.java
@@ -37,10 +37,6 @@ public class FileManager {
         return path.toFile().listFiles();
     }
 
-    public File createFile(FileType fileType, Pool pool, Device device, TestCaseEvent testCaseEvent){
-        return createFile(fileType, pool, device, new TestIdentifier(testCaseEvent.getTestClass(), testCaseEvent.getTestMethod()));
-    }
-
     public File createFile(FileType fileType, Pool pool, Device device, TestIdentifier testIdentifier, int sequenceNumber) {
         try {
             Path directory = createDirectory(fileType, pool, device);

--- a/fork-runner/src/test/java/com/shazam/fork/model/PoolTestCaseAccumulatorTestFailure.java
+++ b/fork-runner/src/test/java/com/shazam/fork/model/PoolTestCaseAccumulatorTestFailure.java
@@ -1,10 +1,15 @@
 package com.shazam.fork.model;
 
+import com.android.ddmlib.testrunner.TestIdentifier;
+
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Collections;
+
 import static com.shazam.fork.model.Device.Builder.aDevice;
 import static com.shazam.fork.model.TestCaseEvent.newTestCase;
+import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -27,8 +32,10 @@ public class PoolTestCaseAccumulatorTestFailure {
             .addDevice(ANOTHER_DEVICE)
             .build();
     
-    private final TestCaseEvent A_TEST_CASE = newTestCase("a_method", "a_class", false);
-    private final TestCaseEvent ANOTHER_TEST_CASE = newTestCase("another_method", "a_class", false);
+    private final TestIdentifier A_TEST_CASE = new TestIdentifier("a_class",
+                                                                  "a_method");
+    private final TestIdentifier ANOTHER_TEST_CASE = new TestIdentifier("a_class",
+                                                                        "another_method");
 
     PoolTestCaseFailureAccumulator subject;
 

--- a/fork-runner/src/test/java/com/shazam/fork/runner/FakePoolTestCaseAccumulator.java
+++ b/fork-runner/src/test/java/com/shazam/fork/runner/FakePoolTestCaseAccumulator.java
@@ -1,5 +1,6 @@
 package com.shazam.fork.runner;
 
+import com.android.ddmlib.testrunner.TestIdentifier;
 import com.shazam.fork.model.Pool;
 import com.shazam.fork.model.PoolTestCaseAccumulator;
 import com.shazam.fork.model.TestCaseEvent;
@@ -18,16 +19,16 @@ public class FakePoolTestCaseAccumulator implements PoolTestCaseAccumulator {
     }
 
     @Override
-    public void record(Pool pool, TestCaseEvent testCaseEvent) {
+    public void record(Pool pool, TestIdentifier testCaseEvent) {
     }
 
     @Override
-    public int getCount(Pool pool, TestCaseEvent testCaseEvent) {
+    public int getCount(Pool pool, TestIdentifier testCaseEvent) {
         return count;
     }
 
     @Override
-    public int getCount(TestCaseEvent testCaseEvent) {
+    public int getCount(TestIdentifier testCaseEvent) {
         return count;
     }
 }

--- a/fork-runner/src/test/java/com/shazam/fork/runner/OverallProgressReporterTest.java
+++ b/fork-runner/src/test/java/com/shazam/fork/runner/OverallProgressReporterTest.java
@@ -1,5 +1,6 @@
 package com.shazam.fork.runner;
 
+import com.android.ddmlib.testrunner.TestIdentifier;
 import com.shazam.fork.model.*;
 
 import org.jmock.Expectations;
@@ -24,7 +25,7 @@ public class OverallProgressReporterTest {
     private final Pool A_POOL = aDevicePool()
             .addDevice(A_DEVICE)
             .build();
-    private final TestCaseEvent A_TEST_CASE = newTestCase("aTestMethod", "aTestClass", false);
+    private final TestIdentifier A_TEST_CASE = new TestIdentifier("aTestClass", "aTestMethod");
 
     private OverallProgressReporter overallProgressReporter;
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 #
 
-VERSION_NAME=2.1.0-SNAPSHOT
+VERSION_NAME=BANNO-SNAPSHOT
 GROUP=com.shazam.fork
 
 POM_LICENCE_NAME=The Apache Software License, Version 2.0


### PR DESCRIPTION
This PR changes the queue of test cases to be class based instead of method based. The issue with basing it off of methods is that there's overhead for each time that you run a tests as it needs to use ADB to instrument the test and a bunch of other stuff. If you're running a whole class, that overhead moves from every method to every class, which can be quite a performance difference.