### PR TITLE
Setup for publishing to Nexus

### DIFF
--- a/build-scripts/gradle-mvn-push.gradle
+++ b/build-scripts/gradle-mvn-push.gradle
@@ -23,13 +23,50 @@ def getRepositoryPassword() {
     return hasProperty('NEXUS_PASSWORD') ? NEXUS_PASSWORD : ""
 }
 
-task assembleRelease(dependsOn: 'assemble') << {
-}
-
 uploadArchives {
     repositories {
         mavenDeployer {
-            repository(url: String.format("file:%s/.m2/repository", System.getProperty("user.home")))
+            beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+
+            pom.groupId = GROUP
+            pom.artifactId = POM_ARTIFACT_ID
+            pom.version = VERSION_NAME
+
+            repository(url: getReleaseRepositoryUrl()) {
+                authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
+            }
+
+            snapshotRepository(url: getSnapshotRepositoryUrl()) {
+                authentication(userName: getRepositoryUsername(), password: getRepositoryPassword())
+            }
+
+            pom.project {
+                name POM_NAME
+                packaging POM_PACKAGING
+                description POM_DESCRIPTION
+                url POM_URL
+
+                scm {
+                    url POM_SCM_URL
+                    connection POM_SCM_CONNECTION
+                    developerConnection POM_SCM_DEV_CONNECTION
+                }
+
+                licenses {
+                    license {
+                        name POM_LICENCE_NAME
+                        url POM_LICENCE_URL
+                        distribution POM_LICENCE_DIST
+                    }
+                }
+
+                developers {
+                    developer {
+                        id POM_DEVELOPER_ID
+                        name POM_DEVELOPER_NAME
+                    }
+                }
+            }
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,15 @@ allprojects {
 }
 
 subprojects {
+    ext {
+        SNAPSHOT_REPOSITORY_URL = System.env.NEXUS_REPOSITORY
+        NEXUS_USERNAME = System.env.NEXUS_USER
+        NEXUS_PASSWORD = System.env.NEXUS_PASSWORD
+    }
+
     afterEvaluate { project ->
+        task assembleRelease(dependsOn: 'assemble')
+
         jacocoTestReport.dependsOn test
         jacocoTestReport.reports.html.enabled false
         jacocoTestReport.reports.xml.enabled true

--- a/chimprunner-gradle-plugin/gradle.properties
+++ b/chimprunner-gradle-plugin/gradle.properties
@@ -8,7 +8,7 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 #
 
-VERSION_NAME=0.9.1-SNAPSHOT
+VERSION_NAME=BANNO-SNAPSHOT
 GROUP=com.shazam.chimprunner
 
 POM_ARTIFACT_ID=chimprunner-gradle-plugin

--- a/chimprunner-gradle-plugin/gradle.properties
+++ b/chimprunner-gradle-plugin/gradle.properties
@@ -8,7 +8,7 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 #
 
-VERSION_NAME=BANNO-SNAPSHOT
+VERSION_NAME=BANNO-300-SNAPSHOT
 GROUP=com.shazam.chimprunner
 
 POM_ARTIFACT_ID=chimprunner-gradle-plugin

--- a/chimprunner/gradle.properties
+++ b/chimprunner/gradle.properties
@@ -7,7 +7,7 @@
 #
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 #
-VERSION_NAME=0.9.1-SNAPSHOT
+VERSION_NAME=BANNO-SNAPSHOT
 GROUP=com.shazam.chimprunner
 
 POM_ARTIFACT_ID=chimprunner

--- a/chimprunner/gradle.properties
+++ b/chimprunner/gradle.properties
@@ -7,7 +7,7 @@
 #
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 #
-VERSION_NAME=BANNO-SNAPSHOT
+VERSION_NAME=BANNO-300-SNAPSHOT
 GROUP=com.shazam.chimprunner
 
 POM_ARTIFACT_ID=chimprunner

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 #
 
-VERSION_NAME=BANNO-SNAPSHOT
+VERSION_NAME=BANNO-300-SNAPSHOT
 GROUP=com.shazam.fork
 
 POM_LICENCE_NAME=The Apache Software License, Version 2.0


### PR DESCRIPTION
Connects to Banno/mobile-android/pull/1810

- Revert `gradle-mvn-push.gradle` to how it was in `fork` master
- Use the Nexus URL and creds defined by environment variables. These will be defined by the Jenkins step added in the above `mobile-android` PR.
- Change the version to `BANNO-$version-SNAPSHOT`
